### PR TITLE
Back end jld73/0.0 b

### DIFF
--- a/back-end/app.js
+++ b/back-end/app.js
@@ -8,6 +8,7 @@ var bodyParser = require('body-parser');
 var index = require('./routes/index');
 var users = require('./routes/users');
 var files = require('./routes/files');
+var scripts = require('./routes/scripts');
 
 var app = express();
 
@@ -27,6 +28,7 @@ app.use(express.static(path.join(__dirname, 'public')));
 app.use('/', index);
 app.use('/users', users);
 app.use('/files', files);
+app.use('/scripts', scripts);
 
 // catch 404 and forward to error handler
 app.use(function(req, res, next) {

--- a/back-end/controllers/scriptManager.js
+++ b/back-end/controllers/scriptManager.js
@@ -1,0 +1,29 @@
+/*
+ * scriptManager.js contains the functions that handle script accesses
+ */
+
+'use strict';
+
+/*
+ * This is a prototype function that returns a default example script.
+ * This should be replaced with an actual database controller
+ */
+
+function getScript( id ) {
+   return "<?xml version\"1.0\"?><script title=\"The Interview\" author=\"Patrick M. Bailey\" license=\"2011\"><roles><character id='1' name='John'/><character id='12' name='Princess'/></roles><act id='2'>t<scene id='2' title='Confrontation'><description>In <em>the</em> castle</description><line id='ABC1234'><!-- line id deterministically generated --><text><em>Princess enters the scene</em></text></line><line id='FEFE332' characterID='12'><text>But daddy, I <em>love</em> him!<!-- can include em, strong tags.--></text></line><!--</scene></act> XML MAY be well-formed (or not) --></script>"
+}
+
+
+/*
+ * getScript returns the xml of the script associated with a certain id
+ *
+ * @param: req.query.id, the id
+ *
+ * @return: Requested script xml
+ */
+exports.getScript = function( req, res ) {
+	var id = req.query.id;
+
+	res.send(getScript(req.id));
+   
+}

--- a/back-end/package.json
+++ b/back-end/package.json
@@ -13,6 +13,6 @@
     "jade": "~1.11.0",
     "morgan": "~1.8.1",
     "mysql": "^2.15.0",
-    "serve-favicon": "~2.4.2"
+    "serve-favicon": "^2.4.5"
   }
 }

--- a/back-end/routes/scripts.js
+++ b/back-end/routes/scripts.js
@@ -1,0 +1,15 @@
+/*
+ * scripts.js Allows scripts to be retrieved
+ */
+
+'use strict';
+
+var express = require( 'express' );
+var router = express.Router();
+var scriptManager = require( '../controllers/scriptManager' );
+
+router.get( '/', function( req, res, next ) {
+	scriptManager.getScript( req, res )
+} );
+
+module.exports = router;


### PR DESCRIPTION
This is for card 0.0B: Create an endpoint that receives a script ID and sends an XML script as a response. This should run with just node/express installed. The test case is accessing /scripts?id=_ returns the xml. Note that currently the xml returned is a default placeholder and that the id number is not used since there is no database system available yet. Also note that the xml is not visible in a standard browser since the tags are parsed as html, but it can however be seen in the page source.